### PR TITLE
hide table headings that are too large

### DIFF
--- a/pqgrid.dev.css
+++ b/pqgrid.dev.css
@@ -153,6 +153,9 @@ div.pq-grid-header_ddn_icon_bg{
 div.ui-resizable-handle{
 	z-index:1;
 }
+div.pq-grid-col{
+	overflow: hidden;
+}
 div.pq-grid-col-resize-handle{
 }
 div.pq-grid tr{


### PR DESCRIPTION
When there are too many, or too long headings for the space available, 
the heading text overlaps - hiding the overflow allows the user to 
change the size without it becoming unreadable :)
