### PR TITLE
add infoData property to dataModel

### DIFF
--- a/pqgrid.dev.js
+++ b/pqgrid.dev.js
@@ -1730,6 +1730,7 @@ fnSB._setOptions=function(){
 							} 
                         }
                     }
+                    if( retObj.infoData ) { DM.infoData = retObj.infoData; }
                     that._refreshDataFromDataModel();
                     if (DM.sorting == "local" && DM.sortIndx != undefined) { 
                         that._refreshSortingDataAndView({sorting:true});


### PR DESCRIPTION
provide additional return data as infoData within the dataModel. This
can be used to process additional return info in load event for remote
data requests.

Possible solution for Issue #34
